### PR TITLE
Override resultclass instead of passing it into constructor

### DIFF
--- a/django_test_timer/__init__.py
+++ b/django_test_timer/__init__.py
@@ -24,10 +24,7 @@ class TimeLoggingTestResult(TextTestResult):
 
 # Django agnostic
 class TimedUnitTestRunner(unittest.TextTestRunner):
-
-    def __init__(self, *args, **kwargs):
-        kwargs['resultclass'] = TimeLoggingTestResult
-        return super(TimedUnitTestRunner, self).__init__(*args, **kwargs)
+    resultclass = TimeLoggingTestResult
 
     def run(self, test):
         result = super(TimedUnitTestRunner, self).run(test)

--- a/django_test_timer/__init__.py
+++ b/django_test_timer/__init__.py
@@ -24,7 +24,9 @@ class TimeLoggingTestResult(TextTestResult):
 
 # Django agnostic
 class TimedUnitTestRunner(unittest.TextTestRunner):
-    resultclass = TimeLoggingTestResult
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('resultclass', TimeLoggingTestResult)
+        return super(TimedUnitTestRunner, self).__init__(*args, **kwargs)
 
     def run(self, test):
         result = super(TimedUnitTestRunner, self).run(test)

--- a/django_test_timer/__init__.py
+++ b/django_test_timer/__init__.py
@@ -24,6 +24,7 @@ class TimeLoggingTestResult(TextTestResult):
 
 # Django agnostic
 class TimedUnitTestRunner(unittest.TextTestRunner):
+
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('resultclass', TimeLoggingTestResult)
         return super(TimedUnitTestRunner, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Enables user to override extend TimeLoggingTestResult class and pass it to the constructor